### PR TITLE
Update docker commands to new syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,15 +72,15 @@ We recommend to use [docker-compose](https://docs.docker.com/compose/) to start 
 
 * If you want to start Cassandra dependency, use `./docker/dev/cassandra.yml`:
 ```
-docker-compose -f ./docker/dev/cassandra.yml up
+docker compose -f ./docker/dev/cassandra.yml up
 ```
-You will use `CTRL+C` to stop it. Then `docker-compose -f ./docker/dev/cassandra.yml down` to clean up the resources.
+You will use `CTRL+C` to stop it. Then `docker compose -f ./docker/dev/cassandra.yml down` to clean up the resources.
 
 Or to run in the background
 ```
-docker-compose -f ./docker/dev/cassandra.yml up -d
+docker compose -f ./docker/dev/cassandra.yml up -d
 ```
-Also use `docker-compose -f ./docker/dev/cassandra.yml down` to stop and clean up the resources.
+Also use `docker compose -f ./docker/dev/cassandra.yml down` to stop and clean up the resources.
 
 * Alternatively, use `./docker/dev/mysql.yml` for MySQL dependency. (MySQL has been updated from 5.7 to 8.0)
 * Alternatively, use `./docker/dev/postgres.yml` for PostgreSQL dependency

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Once you have Cadence backend and worker(s) running, you can trigger workflows b
 1. Start cadence backend components locally
 
 ```
-docker-compose -f docker/docker-compose.yml up
+docker compose -f docker/docker-compose.yml up
 ```
 
 2. Run the Samples

--- a/bench/README.md
+++ b/bench/README.md
@@ -29,7 +29,7 @@ Different ways of start the bench workers:
 You can [pre-built docker-compose file](../docker/docker-compose-bench.yml) to run against local server
 In the `docker/` directory, run:
 ```
-docker-compose -f docker-compose-bench.yml up
+docker compose -f docker-compose-bench.yml up
 ```
 You can modify [the bench worker config](../docker/config/bench/development.yaml) to run against a prod server cluster. 
 

--- a/canary/README.md
+++ b/canary/README.md
@@ -23,7 +23,7 @@ Different ways of start the canary:
 You can [pre-built docker-compose file](../docker/docker-compose-canary.yml) to run against local server
 In the `docker/` directory, run:
 ```
-docker-compose -f docker-compose-canary.yml up
+docker compose -f docker-compose-canary.yml up
 ```
 
 This will start the canary worker and also the cron canary.

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ frontend on ports 7933 (tchannel) / 7833 (grpc), web on port 8088, and grafana o
 
 ```
 cd $GOPATH/src/github.com/uber/cadence/docker
-docker-compose up
+docker compose up
 ```
 > Note: Above command will run with `master-auto-setup` image, which is a changing image all the time.
 > You can use a released image if you want a stable version. See the below section of "Using a released image".
@@ -24,7 +24,7 @@ docker pull ubercadence/server:master-auto-setup
 
 Using different docker-compose files
 -----------------------
-By default `docker-compose up` will run with `docker-compose.yml` in this folder.
+By default `docker compose up` will run with `docker-compose.yml` in this folder.
 This compose file is running with Cassandra, with basic visibility,
 using Prometheus for emitting metric, with Grafana access.
 
@@ -40,7 +40,7 @@ We also provide several other compose files for different features/modes:
 
 For example:
 ```
-docker-compose -f docker-compose-mysql.yml up
+docker compose -f docker-compose-mysql.yml up
 ```
 
 Also feel free to make your own to combine the above features.
@@ -49,11 +49,11 @@ Run canary and bench(load test)
 -----------------------
 After a local cadence server started, use the below command to run canary ro bench test
 ```
-docker-compose -f docker-compose-bench.yml up
+docker compose -f docker-compose-bench.yml up
 ```
 and
 ```
-docker-compose -f docker-compose-canary.yml up
+docker compose -f docker-compose-canary.yml up
 ```
 
 
@@ -74,7 +74,7 @@ commands to start a pre-built image along with all dependencies.
 ```
 tar -xzvf docker.tar.gz
 cd docker
-docker-compose up
+docker compose up
 ```
 
 DIY: Building an image for any tag or branch
@@ -103,8 +103,8 @@ docker build . -t ubercadence/server:YOUR_TAG-auto-setup --build-arg TARGET=auto
 Replace the tag of **image: ubercadence/server** to **YOUR_TAG** in docker-compose.yml .
 Then stop service and remove all containers using the below commands.
 ```
-docker-compose down
-docker-compose up
+docker compose down
+docker compose up
 ```
 
 DIY: Troubleshooting docker builds
@@ -139,7 +139,7 @@ If you want to test out a custom-built cadence server, while running all the nor
 
 Make your cadence server changes and build using "make bins". Then start everything, stop cadence server, and run your own cadence-server:
 ```
-docker-compose up
+docker compose up
 docker stop docker-cadence-1
 ./cadence-server start
 ```

--- a/docker/buildkite/README.md
+++ b/docker/buildkite/README.md
@@ -13,36 +13,36 @@ Build the container for
 
 unit tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml build unit-test
+docker compose -f docker/buildkite/docker-compose-local.yml build unit-test
 ```
 
 NOTE: You would expect TestServerStartup to fail here as we don't have a way to install the schema like we do in pipeline.yml 
 
 integration tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml build integration-test-cassandra
+docker compose -f docker/buildkite/docker-compose-local.yml build integration-test-cassandra
 ```
 
 cross DC integration tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml build integration-test-ndc-cassandra
+docker compose -f docker/buildkite/docker-compose-local.yml build integration-test-ndc-cassandra
 ```
 
 Run the integration tests:
 
 unit tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml run unit-test
+docker compose -f docker/buildkite/docker-compose-local.yml run unit-test
 ```
 
 integration tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml run integration-test-cassandra
+docker compose -f docker/buildkite/docker-compose-local.yml run integration-test-cassandra
 ```
 
 cross DC integration tests:
 ```bash
-docker-compose -f docker/buildkite/docker-compose-local.yml run integration-test-ndc-cassandra
+docker compose -f docker/buildkite/docker-compose-local.yml run integration-test-ndc-cassandra
 ```
 
 Note that BuildKite will run basically the same commands.

--- a/docs/howtos/cassandra-fql.md
+++ b/docs/howtos/cassandra-fql.md
@@ -2,7 +2,7 @@
 
 1. Run cadence components via docker compose
 ```
-docker-compose docker/docker-compose.yml up
+docker compose docker/docker-compose.yml up
 ```
 
 2. First enable fql via nodetool ([ref](https://cassandra.apache.org/doc/stable/cassandra/operating/fqllogging.html#enabling-fql))

--- a/docs/visibility-on-elasticsearch.md
+++ b/docs/visibility-on-elasticsearch.md
@@ -16,7 +16,7 @@ That's why Cadence add support for enhanced visibility features on top of Elasti
 ## Local Cadence Docker Setup
 1. Increase docker memory to higher 6GB. Docker -> Preference -> advanced -> memory limit
 2. Get docker compose file. Run `curl -O https://raw.githubusercontent.com/uber/cadence/master/docker/docker-compose-es.yml`
-3. Start cadence docker which contains Kafka, Zookeeper and ElasticSearch. Run `docker-compose -f docker-compose-es.yml up`
+3. Start cadence docker which contains Kafka, Zookeeper and ElasticSearch. Run `docker compose -f docker-compose-es.yml up`
 4. From docker output log, make sure ES and cadence started correctly. If encounter disk space not enough, try `docker system prune -a --volumes`
 5. Register local domain and start using it. `cadence --do samples-domain d re`
 

--- a/host/async_wf_test.go
+++ b/host/async_wf_test.go
@@ -26,15 +26,15 @@ To run locally:
 
 1. Stop the previous run if any
 
-	docker-compose -f docker/buildkite/docker-compose-local-async-wf.yml down
+	docker compose -f docker/buildkite/docker-compose-local-async-wf.yml down
 
 2. Build the integration-test-async-wf image
 
-	docker-compose -f docker/buildkite/docker-compose-local-async-wf.yml build integration-test-async-wf
+	docker compose -f docker/buildkite/docker-compose-local-async-wf.yml build integration-test-async-wf
 
 3. Run the test in the docker container
 
-	docker-compose -f docker/buildkite/docker-compose-local-async-wf.yml run --rm integration-test-async-wf
+	docker compose -f docker/buildkite/docker-compose-local-async-wf.yml run --rm integration-test-async-wf
 
 4. Full test run logs can be found at test.log file
 */

--- a/host/cassandra_lwt_test.go
+++ b/host/cassandra_lwt_test.go
@@ -26,15 +26,15 @@ To run locally:
 
 1. Stop the previous run if any
 
-	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml down
+	docker compose -f docker/buildkite/docker-compose-cassandra-lwt.yml down
 
 2. Build the integration-test-async-wf image
 
-	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml build test-cass-lwt
+	docker compose -f docker/buildkite/docker-compose-cassandra-lwt.yml build test-cass-lwt
 
 3. Run the test in the docker container
 
-	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml run --rm test-cass-lwt
+	docker compose -f docker/buildkite/docker-compose-cassandra-lwt.yml run --rm test-cass-lwt
 
 4. Full test run logs can be found at test.log file
 */

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -25,13 +25,13 @@
 To run locally with docker containers:
 
 1. Stop the previous run if any
-	docker-compose -f docker/buildkite/docker-compose-local-pinot.yml down
+	docker compose -f docker/buildkite/docker-compose-local-pinot.yml down
 
 2. Build the integration-test-async-wf image
-	docker-compose -f docker/buildkite/docker-compose-local-pinot.yml build integration-test-cassandra-pinot
+	docker compose -f docker/buildkite/docker-compose-local-pinot.yml build integration-test-cassandra-pinot
 
 3. Run the test in the docker container
-	docker-compose -f docker/buildkite/docker-compose-local-pinot.yml run --rm integration-test-cassandra-pinot
+	docker compose -f docker/buildkite/docker-compose-local-pinot.yml run --rm integration-test-cassandra-pinot
 
 To run locally natively (without docker),
 1. make sure kafka and pinot is running,

--- a/scripts/run_cass_and_test.sh
+++ b/scripts/run_cass_and_test.sh
@@ -4,16 +4,16 @@ set -eo pipefail
 
 function finish {
   echo "shut down containers"
-  docker-compose -f docker/docker-compose.yml down;
+  docker compose -f docker/docker-compose.yml down;
 }
 trap finish EXIT
 
 # shut down containers
-docker-compose -f docker/docker-compose.yml down;
+docker compose -f docker/docker-compose.yml down;
 
 # run cassandra & cadence container
 # we need cadence here because it handles db setup
-docker-compose -f docker/docker-compose.yml up -d cassandra cadence;
+docker compose -f docker/docker-compose.yml up -d cassandra cadence;
 
 status=""
 while [[ "$status" != "running" ]]; do

--- a/service/worker/README.md
+++ b/service/worker/README.md
@@ -16,7 +16,7 @@ Quickstart for local development with multiple Cadence clusters and replication
 ====================================
 1. Start dependency using docker if you don't have one running:
 ```
-docker-compose -f docker/dev/cassandra.yml up
+docker compose -f docker/dev/cassandra.yml up
 ```
 Then install the schemas:
 ```

--- a/service/worker/scanner/README.md
+++ b/service/worker/scanner/README.md
@@ -199,10 +199,10 @@ but this is the way I did things when reading and changing this code:
 2. Make your config/code/etc changes locally for scanner / fixer.
 3. `make cadence-server` to ensure it builds
 4. `./cadence-server start --services worker` to start up a worker that will
-   connect to your docker-compose cluster.
+   connect to your docker compose cluster.
 5. Browse history via the web UI, usually http://localhost:8088/domains/cadence-system/workflows
 
-The default docker-compose setup starts a worker instance, but due to the default
+The default docker compose setup starts a worker instance, but due to the default
 dynamic config setup where all but `worker.taskListScannerEnabled` are disabled,
 the in-docker worker will not run (most) scanner/fixer tasklists and will not steal
 any tasks from a local worker.
@@ -210,15 +210,15 @@ any tasks from a local worker.
 So you can often simply run it without any changes, start up your local (customized)
 worker service outside of docker, and everything will Just Work™.
 
-This way you can leverage the normal docker-compose yaml files with minimal effort,
+This way you can leverage the normal docker compose yaml files with minimal effort,
 use the web UI to observe the results, and rapidly change/rebuild/rerun/debug/etc
 without needing to deal with docker.
 
 If you **do** need to debug the tasklist scanner, I would recommend making a custom build,
-and modifying the docker-compose file to use your build.  Details on that are below,
+and modifying the docker compose file to use your build.  Details on that are below,
 but they **are not necessary** for other scanners/fixers.
 
-### Docker-compose changes (tasklist scanner only)
+### Docker compose changes (tasklist scanner only)
 
 There are a few ways to achieve this, but I like modifying the `docker-compose*.yaml`
 file to use a custom local build, and just changing its dynamic config to disable
@@ -226,7 +226,7 @@ the tasklist scanner.
 
 To do that, see the [docker/README.md file](../../../docker/README.md) for instructions.
 Personally I prefer making a unique auto-setup tag so it does not replace any non-customized
-docker-compose runs in the future.  E.g.:
+docker compose runs in the future.  E.g.:
 ```yaml
 services:
   # ...

--- a/simulation/history/run.sh
+++ b/simulation/history/run.sh
@@ -16,7 +16,7 @@ eventLogsFile="$resultFolder/$testName-events.json"
 testSummaryFile="$resultFolder/$testName-summary.txt"
 
 echo "Building test image"
-docker-compose -f docker/buildkite/docker-compose-local-history-simulation.yml \
+docker compose -f docker/buildkite/docker-compose-local-history-simulation.yml \
   build history-simulator
 
 function check_test_failure()
@@ -37,7 +37,7 @@ function check_test_failure()
 trap check_test_failure EXIT
 
 echo "Running the test $testCase"
-docker-compose \
+docker compose \
   -f docker/buildkite/docker-compose-local-history-simulation.yml \
   run -e HISTORY_SIMULATION_CONFIG=$testCfg --rm --remove-orphans --service-ports --use-aliases \
   history-simulator \

--- a/simulation/matching/run.sh
+++ b/simulation/matching/run.sh
@@ -16,7 +16,7 @@ eventLogsFile="$resultFolder/$testName-events.json"
 testSummaryFile="$resultFolder/$testName-summary.txt"
 
 echo "Building test image"
-docker-compose -f docker/buildkite/docker-compose-local-matching-simulation.yml \
+docker compose -f docker/buildkite/docker-compose-local-matching-simulation.yml \
   build matching-simulator
 
 function check_test_failure()
@@ -37,7 +37,7 @@ function check_test_failure()
 trap check_test_failure EXIT
 
 echo "Running the test $testCase"
-docker-compose \
+docker compose \
   -f docker/buildkite/docker-compose-local-matching-simulation.yml \
   run -e MATCHING_SIMULATION_CONFIG=$testCfg --rm --remove-orphans --service-ports --use-aliases \
   matching-simulator \


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replaced all instances of `docker-compose` commands with `docker compose` in documentation, scripts, and test files.

**Why?**
The Docker CLI now includes `compose` as a subcommand, eliminating the need for a separate `docker-compose` binary. This change modernizes command usage, reduces external dependencies, and ensures consistency with current Docker recommendations.

**How did you test it?**
Manually verified updated `docker compose` commands in key `README.md` and `CONTRIBUTING.md` files.

**Potential risks**
Minimal. The `docker compose` subcommand is generally backward-compatible with `docker-compose`. The primary risk is a missed instance of `docker-compose` or an edge case where the new command behaves unexpectedly (unlikely for basic operations like `up`, `down`, `build`, `run`).

**Release notes**
Not notable for release. This is a developer experience and documentation update.

**Documentation Changes**
Documentation files (e.g., `README.md`, `CONTRIBUTING.md`, `docker/README.md`) have been updated as part of this PR.